### PR TITLE
Return false when is lambda is run via ServerLess Framework

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
 module.exports = !!(
-  process.env.AWS_EXECUTION_ENV ||
+  (process.env.LAMBDA_TASK_ROOT && process.env.AWS_EXECUTION_ENV) ||
   false
 )

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
 module.exports = !!(
-  process.env.LAMBDA_TASK_ROOT ||
+  process.env.AWS_EXECUTION_ENV ||
   false
 )

--- a/test.js
+++ b/test.js
@@ -4,6 +4,7 @@ var assert = require('assert')
 var clearRequire = require('clear-require')
 
 process.env.AWS_EXECUTION_ENV = 'AWS_Lambda_nodejs6.10'
+process.env.LAMBDA_TASK_ROOT = '/var/task'
 
 var isCI = require('./')
 assert(isCI)

--- a/test.js
+++ b/test.js
@@ -3,12 +3,12 @@
 var assert = require('assert')
 var clearRequire = require('clear-require')
 
-process.env.LAMBDA_TASK_ROOT = '/var/task'
+process.env.AWS_EXECUTION_ENV = 'AWS_Lambda_nodejs6.10'
 
 var isCI = require('./')
 assert(isCI)
 
-delete process.env.LAMBDA_TASK_ROOT
+delete process.env.AWS_EXECUTION_ENV
 
 clearRequire('./')
 isCI = require('./')


### PR DESCRIPTION
Serverless framework auto define the environment variable LAMBDA_TASK_ROOT when you run task locally.

serverless invoke local -f <functionname>

AWS_EXECUTION_ENV it's only defined via the real AWS Lambda server.